### PR TITLE
#3 Fixes crash related to response error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 install:
   - npm install
 script:
-  - npm test
+  - npm run full-test
 deploy:
   provider: npm
   email: $NPM_EMAIL

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "pimbridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest --verbose --silent"
+    "test": "jest --verbose --silent",
+    "lint": "./node_modules/.bin/eslint --ext .js ./",
+    "full-test": "npm run lint && npm run test"
   },
   "jest": {
     "testURL": "http://localhost/"

--- a/src/pimbridge.js
+++ b/src/pimbridge.js
@@ -81,7 +81,13 @@ function Pimbridge(pimcoreAccess = {}) {
 
     // All infor of object needs to be provided in update,
     // so we'll retrieve all customer data prior to applying changes
-    const resourceObject = (await get(resource, params.id)).data;
+    const resourceQuery = await get(resource, params.id);
+
+    if (resourceQuery.error) {
+      return resourceQuery;
+    }
+
+    const resourceObject = resourceQuery.data;
     const updates = Object.keys(params);
 
     // There's nothing to do if id is the only param


### PR DESCRIPTION
Fixes issue #3.
- Created new method, handleError, to better handle errors from both axios and pimcore.
- Added unit tests for new method.
- Expanded existing unit tests to test error handling of existing pimbridge options.
- Fixed bug found in update function of pimbridge (whole function fails without proper error handling if first api call in method fails).
- Added linting script to package to make sure proper linting rules are followed.
- Added full-test script to package that will be called by Travis and test both unit tests and linting errors.
